### PR TITLE
Lists: remove "Totals by Year" charts from Budgets, Planned Disbursem…

### DIFF
--- a/frontend/src/app/budgets/page.tsx
+++ b/frontend/src/app/budgets/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect } from "react";
 import { MainLayout } from "@/components/layout/main-layout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -19,10 +19,7 @@ import { useBudgets } from "@/hooks/useBudgets";
 import { Budget, BudgetFilter } from "@/types/budget";
 import { BulkActionToolbar } from "@/components/ui/bulk-action-toolbar";
 import { BulkDeleteDialog } from "@/components/dialogs/bulk-delete-dialog";
-import { YearlyTotalsBarChart, SingleSeriesDataPoint } from "@/components/charts/YearlyTotalsBarChart";
 import { useLoadingBar } from "@/hooks/useLoadingBar";
-import { CustomYearSelector } from "@/components/ui/custom-year-selector";
-import { useCustomYears } from "@/hooks/useCustomYears";
 import { BudgetsListSkeleton } from "@/components/skeletons/FullScreenSkeletons";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { apiFetch } from '@/lib/api-fetch';
@@ -57,42 +54,6 @@ export default function BudgetsPage() {
     dateFrom: "",
     dateTo: "",
   });
-
-  // Yearly summary state for chart
-  const [yearlySummary, setYearlySummary] = useState<SingleSeriesDataPoint[]>([]);
-  const [yearlySummaryLoading, setYearlySummaryLoading] = useState(true);
-
-  // Custom year selection for chart
-  const { customYears, selectedId: selectedCustomYearId, setSelectedId: setSelectedCustomYearId, selectedYear, loading: customYearsLoading } = useCustomYears();
-
-  // Year range filter for chart
-  const [chartStartYear, setChartStartYear] = useState<number | null>(null);
-  const [chartEndYear, setChartEndYear] = useState<number | null>(null);
-
-  // Filter yearly summary data by year range
-  const filteredYearlySummary = useMemo(() => {
-    if (!yearlySummary) return [];
-    return yearlySummary.filter(item => {
-      if (chartStartYear && item.year < chartStartYear) return false;
-      if (chartEndYear && item.year > chartEndYear) return false;
-      return true;
-    });
-  }, [yearlySummary, chartStartYear, chartEndYear]);
-
-  // Calculate actual data year range (from unfiltered data)
-  const dataYearRange = useMemo(() => {
-    if (!yearlySummary || yearlySummary.length === 0) return { min: null, max: null };
-    const years = yearlySummary.map(d => d.year);
-    return { min: Math.min(...years), max: Math.max(...years) };
-  }, [yearlySummary]);
-
-  // Auto-select "Data" range when data first loads
-  useEffect(() => {
-    if (dataYearRange.min !== null && dataYearRange.max !== null && chartStartYear === null && chartEndYear === null) {
-      setChartStartYear(dataYearRange.min);
-      setChartEndYear(dataYearRange.max);
-    }
-  }, [dataYearRange.min, dataYearRange.max, chartStartYear, chartEndYear]);
 
   // Use the custom hook to fetch budgets
   const { budgets, loading, error, refetch, deleteBudget, addBudget } = useBudgets({
@@ -130,40 +91,6 @@ export default function BudgetsPage() {
       console.error('Error fetching organizations:', error);
     }
   };
-
-  // Fetch yearly summary when filters change
-  useEffect(() => {
-    const fetchYearlySummary = async () => {
-      setYearlySummaryLoading(true);
-      try {
-        const params = new URLSearchParams();
-        if (filters.types.length > 0) params.append('types', filters.types.join(','));
-        if (filters.statuses.length > 0) params.append('statuses', filters.statuses.join(','));
-        if (filters.organizations.length > 0) params.append('organizations', filters.organizations.join(','));
-        if (searchQuery) params.append('search', searchQuery);
-        
-        // Add custom year params if selected
-        if (selectedYear) {
-          params.append('startMonth', selectedYear.startMonth.toString());
-          params.append('startDay', selectedYear.startDay.toString());
-          params.append('endMonth', selectedYear.endMonth.toString());
-          params.append('endDay', selectedYear.endDay.toString());
-        }
-
-        const response = await apiFetch(`/api/budgets/yearly-summary?${params.toString()}`);
-        if (response.ok) {
-          const data = await response.json();
-          setYearlySummary(data.years || []);
-        }
-      } catch (error) {
-        console.error('Error fetching yearly summary:', error);
-      } finally {
-        setYearlySummaryLoading(false);
-      }
-    };
-
-    fetchYearlySummary();
-  }, [filters, searchQuery, selectedYear]);
 
   // Reset to page 1 when filters change
   useEffect(() => {
@@ -491,33 +418,6 @@ export default function BudgetsPage() {
               />
             </div>
         </FilterBar>
-
-        {/* Yearly Summary Chart */}
-        <YearlyTotalsBarChart
-          title="Budget Totals by Year"
-          description="Yearly budget totals in USD (filtered)"
-          loading={yearlySummaryLoading}
-          singleSeriesData={filteredYearlySummary}
-          singleSeriesColor="#4c5568"
-          singleSeriesLabel="Budget"
-          height={280}
-          selectedYear={selectedYear}
-          startYear={chartStartYear}
-          endYear={chartEndYear}
-          onStartYearChange={setChartStartYear}
-          onEndYearChange={setChartEndYear}
-          dataMinYear={dataYearRange.min}
-          dataMaxYear={dataYearRange.max}
-          headerControls={
-            <CustomYearSelector
-              customYears={customYears}
-              selectedId={selectedCustomYearId}
-              onSelect={setSelectedCustomYearId}
-              loading={customYearsLoading}
-              placeholder="Year Type"
-            />
-          }
-        />
 
         {/* Budgets Table */}
         {loading && sortedBudgets.length === 0 && !searchQuery ? (

--- a/frontend/src/app/planned-disbursements/page.tsx
+++ b/frontend/src/app/planned-disbursements/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect } from "react";
 import { MainLayout } from "@/components/layout/main-layout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -23,10 +23,7 @@ import {
 } from "@/components/planned-disbursements/PlannedDisbursementsTable";
 import { BulkActionToolbar } from "@/components/ui/bulk-action-toolbar";
 import { BulkDeleteDialog } from "@/components/dialogs/bulk-delete-dialog";
-import { YearlyTotalsBarChart, SingleSeriesDataPoint } from "@/components/charts/YearlyTotalsBarChart";
 import { useLoadingBar } from "@/hooks/useLoadingBar";
-import { CustomYearSelector } from "@/components/ui/custom-year-selector";
-import { useCustomYears } from "@/hooks/useCustomYears";
 import { PlannedDisbursementsListSkeleton } from "@/components/skeletons/FullScreenSkeletons";
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { apiFetch } from '@/lib/api-fetch';
@@ -78,42 +75,6 @@ export default function PlannedDisbursementsPage() {
       localStorage.setItem(PLANNED_DISBURSEMENT_COLUMNS_LOCALSTORAGE_KEY, JSON.stringify(visibleColumns));
     }
   }, [visibleColumns]);
-
-  // Yearly summary state for chart
-  const [yearlySummary, setYearlySummary] = useState<SingleSeriesDataPoint[]>([]);
-  const [yearlySummaryLoading, setYearlySummaryLoading] = useState(true);
-
-  // Custom year selection for chart
-  const { customYears, selectedId: selectedCustomYearId, setSelectedId: setSelectedCustomYearId, selectedYear, loading: customYearsLoading } = useCustomYears();
-
-  // Year range filter for chart
-  const [chartStartYear, setChartStartYear] = useState<number | null>(null);
-  const [chartEndYear, setChartEndYear] = useState<number | null>(null);
-
-  // Filter yearly summary data by year range
-  const filteredYearlySummary = useMemo(() => {
-    if (!yearlySummary) return [];
-    return yearlySummary.filter(item => {
-      if (chartStartYear && item.year < chartStartYear) return false;
-      if (chartEndYear && item.year > chartEndYear) return false;
-      return true;
-    });
-  }, [yearlySummary, chartStartYear, chartEndYear]);
-
-  // Calculate actual data year range (from unfiltered data)
-  const dataYearRange = useMemo(() => {
-    if (!yearlySummary || yearlySummary.length === 0) return { min: null, max: null };
-    const years = yearlySummary.map(d => d.year);
-    return { min: Math.min(...years), max: Math.max(...years) };
-  }, [yearlySummary]);
-
-  // Auto-select "Data" range when data first loads
-  useEffect(() => {
-    if (dataYearRange.min !== null && dataYearRange.max !== null && chartStartYear === null && chartEndYear === null) {
-      setChartStartYear(dataYearRange.min);
-      setChartEndYear(dataYearRange.max);
-    }
-  }, [dataYearRange.min, dataYearRange.max, chartStartYear, chartEndYear]);
 
   // Global loading bar for top-of-screen progress indicator
   const { startLoading, stopLoading } = useLoadingBar();
@@ -187,41 +148,6 @@ export default function PlannedDisbursementsPage() {
       setLoading(false);
     }
   };
-
-  // Fetch yearly summary when filters change
-  useEffect(() => {
-    const fetchYearlySummary = async () => {
-      setYearlySummaryLoading(true);
-      try {
-        const params = new URLSearchParams();
-        // Pass types as comma-separated values if any are selected
-        if (filters.types.length > 0) params.append('types', filters.types.join(','));
-        // Pass organizations as comma-separated values if any are selected
-        if (filters.organizations.length > 0) params.append('organizations', filters.organizations.join(','));
-        if (searchQuery) params.append('search', searchQuery);
-        
-        // Add custom year params if selected
-        if (selectedYear) {
-          params.append('startMonth', selectedYear.startMonth.toString());
-          params.append('startDay', selectedYear.startDay.toString());
-          params.append('endMonth', selectedYear.endMonth.toString());
-          params.append('endDay', selectedYear.endDay.toString());
-        }
-
-        const response = await apiFetch(`/api/planned-disbursements/yearly-summary?${params.toString()}`);
-        if (response.ok) {
-          const data = await response.json();
-          setYearlySummary(data.years || []);
-        }
-      } catch (error) {
-        console.error('Error fetching yearly summary:', error);
-      } finally {
-        setYearlySummaryLoading(false);
-      }
-    };
-
-    fetchYearlySummary();
-  }, [filters, searchQuery, selectedYear]);
 
   // Reset to page 1 when filters change
   useEffect(() => {
@@ -469,33 +395,6 @@ export default function PlannedDisbursementsPage() {
               />
             </div>
         </FilterBar>
-
-        {/* Yearly Summary Chart */}
-        <YearlyTotalsBarChart
-          title="Planned Disbursement Totals by Year"
-          description="Yearly planned disbursement totals in USD (filtered)"
-          loading={yearlySummaryLoading}
-          singleSeriesData={filteredYearlySummary}
-          singleSeriesColor="#7b95a7"
-          singleSeriesLabel="Planned Disbursement"
-          height={280}
-          selectedYear={selectedYear}
-          startYear={chartStartYear}
-          endYear={chartEndYear}
-          onStartYearChange={setChartStartYear}
-          onEndYearChange={setChartEndYear}
-          dataMinYear={dataYearRange.min}
-          dataMaxYear={dataYearRange.max}
-          headerControls={
-            <CustomYearSelector
-              customYears={customYears}
-              selectedId={selectedCustomYearId}
-              onSelect={setSelectedCustomYearId}
-              loading={customYearsLoading}
-              placeholder="Year Type"
-            />
-          }
-        />
 
         {/* Planned Disbursements Table */}
         {loading && disbursements.length === 0 ? (

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState, useEffect, useCallback, useMemo } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { MainLayout } from "@/components/layout/main-layout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -32,10 +32,7 @@ import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { useCurrencyConverter } from "@/hooks/useCurrencyConverter";
 import { BulkActionToolbar } from "@/components/ui/bulk-action-toolbar";
 import { BulkDeleteDialog } from "@/components/dialogs/bulk-delete-dialog";
-import { YearlyTotalsBarChart, MultiSeriesDataPoint } from "@/components/charts/YearlyTotalsBarChart";
 import { useLoadingBar } from "@/hooks/useLoadingBar";
-import { CustomYearSelector } from "@/components/ui/custom-year-selector";
-import { useCustomYears } from "@/hooks/useCustomYears";
 import { apiFetch } from '@/lib/api-fetch';
 
 type FilterState = {
@@ -87,41 +84,6 @@ export default function TransactionsPage() {
     transactionSource: "all",
   });
 
-  // Yearly summary state for chart
-  const [yearlySummary, setYearlySummary] = useState<MultiSeriesDataPoint[]>([]);
-  const [yearlySummaryLoading, setYearlySummaryLoading] = useState(true);
-
-  // Custom year selection for chart
-  const { customYears, selectedId: selectedCustomYearId, setSelectedId: setSelectedCustomYearId, selectedYear, loading: customYearsLoading } = useCustomYears();
-
-  // Year range filter for chart
-  const [chartStartYear, setChartStartYear] = useState<number | null>(null);
-  const [chartEndYear, setChartEndYear] = useState<number | null>(null);
-
-  // Filter yearly summary data by year range
-  const filteredYearlySummary = useMemo(() => {
-    if (!yearlySummary) return [];
-    return yearlySummary.filter(item => {
-      if (chartStartYear && item.year < chartStartYear) return false;
-      if (chartEndYear && item.year > chartEndYear) return false;
-      return true;
-    });
-  }, [yearlySummary, chartStartYear, chartEndYear]);
-
-  // Calculate actual data year range (from unfiltered data)
-  const dataYearRange = useMemo(() => {
-    if (!yearlySummary || yearlySummary.length === 0) return { min: null, max: null };
-    const years = yearlySummary.map(d => d.year);
-    return { min: Math.min(...years), max: Math.max(...years) };
-  }, [yearlySummary]);
-
-  // Auto-select "Data" range when data first loads
-  useEffect(() => {
-    if (dataYearRange.min !== null && dataYearRange.max !== null && chartStartYear === null && chartEndYear === null) {
-      setChartStartYear(dataYearRange.min);
-      setChartEndYear(dataYearRange.max);
-    }
-  }, [dataYearRange.min, dataYearRange.max, chartStartYear, chartEndYear]);
 
   // Use the custom hook to fetch transactions (without sorting - we'll sort client-side)
   const { transactions, loading, error, refetch, deleteTransaction, addTransaction, acceptTransaction, rejectTransaction } = useTransactions({
@@ -216,44 +178,6 @@ export default function TransactionsPage() {
       console.error('Error fetching finance types:', error);
     }
   };
-
-  // Fetch yearly summary when filters change
-  useEffect(() => {
-    const fetchYearlySummary = async () => {
-      setYearlySummaryLoading(true);
-      try {
-        const params = new URLSearchParams();
-        if (filters.transactionTypes.length > 0) params.append('transactionTypes', filters.transactionTypes.join(','));
-        if (filters.statuses.length > 0) params.append('statuses', filters.statuses.join(','));
-        if (filters.organizations.length > 0) params.append('organizations', filters.organizations.join(','));
-        if (filters.financeTypes.length > 0) params.append('financeTypes', filters.financeTypes.join(','));
-        if (filters.flowType !== 'all') params.append('flowType', filters.flowType);
-        if (filters.dateFrom) params.append('dateFrom', filters.dateFrom);
-        if (filters.dateTo) params.append('dateTo', filters.dateTo);
-        if (searchQuery) params.append('search', searchQuery);
-        
-        // Add custom year params if selected
-        if (selectedYear) {
-          params.append('startMonth', selectedYear.startMonth.toString());
-          params.append('startDay', selectedYear.startDay.toString());
-          params.append('endMonth', selectedYear.endMonth.toString());
-          params.append('endDay', selectedYear.endDay.toString());
-        }
-
-        const response = await apiFetch(`/api/transactions/yearly-summary?${params.toString()}`);
-        if (response.ok) {
-          const data = await response.json();
-          setYearlySummary(data.years || []);
-        }
-      } catch (error) {
-        console.error('Error fetching yearly summary:', error);
-      } finally {
-        setYearlySummaryLoading(false);
-      }
-    };
-
-    fetchYearlySummary();
-  }, [filters, searchQuery, selectedYear]);
 
   // Reset to page 1 when filters change (but not when sorting changes)
   useEffect(() => {
@@ -838,33 +762,6 @@ export default function TransactionsPage() {
             ⚠️ Showing {transactions?.total || 0} items may affect performance
           </div>
         )}
-
-        {/* Yearly Summary Chart */}
-        <div data-tour="transactions-chart">
-        <YearlyTotalsBarChart
-          title="Transaction Totals by Year"
-          description="Yearly totals by transaction type (filtered)"
-          loading={yearlySummaryLoading}
-          multiSeriesData={filteredYearlySummary}
-          height={280}
-          selectedYear={selectedYear}
-          startYear={chartStartYear}
-          endYear={chartEndYear}
-          onStartYearChange={setChartStartYear}
-          onEndYearChange={setChartEndYear}
-          dataMinYear={dataYearRange.min}
-          dataMaxYear={dataYearRange.max}
-          headerControls={
-            <CustomYearSelector
-              customYears={customYears}
-              selectedId={selectedCustomYearId}
-              onSelect={setSelectedCustomYearId}
-              loading={customYearsLoading}
-              placeholder="Year Type"
-            />
-          }
-        />
-        </div>
 
         {/* Transactions Table */}
         {loading ? (


### PR DESCRIPTION
…ents, Transactions

Removes the YearlyTotalsBarChart card from each finance list page along with its supporting state, fetch effect, and now-unused imports.