### PR TITLE
fix(ui): self-provide TooltipProvider in CopyableIdBadge

### DIFF
--- a/frontend/src/components/ui/copyable-id-badge.tsx
+++ b/frontend/src/components/ui/copyable-id-badge.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils"
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 
@@ -47,28 +48,33 @@ export function CopyableIdBadge({
   }
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <button
-          type="button"
-          onClick={handleCopy}
-          aria-label={`Copy ${label} to clipboard`}
-          className={cn(
-            "text-xs font-mono text-muted-foreground bg-muted",
-            "hover:bg-muted/80 hover:text-foreground",
-            "transition-colors px-1.5 py-0.5 rounded",
-            "inline-flex items-center gap-1 align-middle cursor-pointer max-w-full",
-            "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-            className,
-          )}
-        >
-          <span className="break-all text-left">{value}</span>
-          {showCheckOnCopy && copied && (
-            <Check className="h-3 w-3 text-[hsl(var(--success-icon))] flex-shrink-0" />
-          )}
-        </button>
-      </TooltipTrigger>
-      <TooltipContent>{tooltip}</TooltipContent>
-    </Tooltip>
+    // Self-contained TooltipProvider so the badge can be used anywhere —
+    // including inside CardShell banner overlays and other contexts that don't
+    // sit under a parent provider. Nested providers are tolerated by Radix.
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={handleCopy}
+            aria-label={`Copy ${label} to clipboard`}
+            className={cn(
+              "text-xs font-mono text-muted-foreground bg-muted",
+              "hover:bg-muted/80 hover:text-foreground",
+              "transition-colors px-1.5 py-0.5 rounded",
+              "inline-flex items-center gap-1 align-middle cursor-pointer max-w-full",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              className,
+            )}
+          >
+            <span className="break-all text-left">{value}</span>
+            {showCheckOnCopy && copied && (
+              <Check className="h-3 w-3 text-[hsl(var(--success-icon))] flex-shrink-0" />
+            )}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   )
 }


### PR DESCRIPTION
The badge renders a Radix <Tooltip> but did not include its own <TooltipProvider>, and there is no app-wide provider in MainLayout. Any render path that does not happen to wrap its own provider — most notably OrganizationCardModern's bannerOverlay inside CardShell, which is the default card view on /organizations — crashed at mount with "Tooltip must be used within TooltipProvider" (Radix v1.2+).

Table view masked the bug because each cell wraps its own provider per-tooltip; the card view (default) had no wrapping provider above the badge.

Wrapping the badge's <Tooltip> with its own <TooltipProvider> makes it safe to drop into any context. Nested providers are tolerated by Radix, so existing call sites that already sit under a provider are unaffected.